### PR TITLE
Provide array based API. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["SimonDanisch <sdanisch@gmail.com>", "Juergen Fuhrmann <juergen.fuhrm
 version = "0.2.0"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Documenter, TetGen
+
+function make_all()
+    makedocs(
+
+        sitename="TetGen.jl",
+        modules = [TetGen],
+        clean = true,
+        doctest = false,
+        authors = "Simon Danisch, Juergen Fuhrmann",
+        repo="https://github.com/JuliaGeometry/TetGen.jl",
+        pages=[ 
+            "Home"=>"index.md"
+        ]
+    )
+    
+    if !isinteractive()
+        deploydocs(repo = "github.com/JuliaGeometry/TetGen.jl.git")
+    end
+end
+
+make_all()

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,38 @@
+# TetGen.jl
+
+TetGen  is a  mesh generator  written in  C++.  It  generates Delaunay
+tetrahedralizations,  constrained  Delaunay  tetrahedralizations,  and
+quality tetrahedral  meshes. TetGen.jl  provides a Julia  interface to
+TetGen.
+
+## Mesh based API
+This API uses instances of types from [GeometryBasics.jl](https://github.com/JuliaGeometry/GeometryBasics.jl) 
+to describe input and output of TetGen.
+
+```@autodocs
+Modules = [TetGen]
+Pages = ["api.jl"]
+```
+
+## Raw API
+This API is closer to TetGen's C++ API in the sense that
+input and output are described using arrays of integers
+and floats, without conversion to any other higher level
+data structure.
+
+```@autodocs
+Modules = [TetGen]
+Pages = [ "rawtetgenio.jl"]
+```
+
+
+## TetGen C++ code
+
+- [Technical report](http://doi.org/10.20347/WIAS.TECHREPORT.13)
+  ([html version](http://wias-berlin.de/software/tetgen/1.5/doc/manual/index.html)).
+
+- H.Si, "TetGen, a Delaunay-Based Quality Tetrahedral Mesh Generator" [ACM Trans. Math. Software, 41 (2015) pp. 11:1--11:36](https://dl.acm.org/doi/abs/10.1145/2629697).
+  Please consider citing this paper when publishing results obtained with the use of TetGen.
+  Link to preprint  [here](http://doi.org/10.20347/WIAS.PREPRINT.1762). 
+
+

--- a/examples/examples.jl
+++ b/examples/examples.jl
@@ -1,0 +1,141 @@
+using TetGen
+
+"""
+     random_delaunay(;npoints=20)
+
+Create a Delaunay tetrahedralization  from a random set of points.
+This is  a tetrahedralization of the convex hull of the points.
+If the points are in general position (which we assume here),
+it is unique.
+"""
+function random_delaunay(;npoints=20)
+    input=TetGen.RawTetGenIO{Cdouble}(pointlist=rand(3,npoints))
+    tetrahedralize(input, "Q")
+end
+
+"""
+   cube(;vol=1)
+
+Tetrahedralization of cube witn maximum tetrahedron volume.
+"""
+function cube(;vol=1)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     1 1 1;
+                     0 1 1]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8]')
+    tetrahedralize(input, "pQa$(vol)")
+end
+
+"""
+   prism(;vol=1)
+
+Tetrahedralization of a prism with maximum tetrahedron volume.
+"""
+function prism(vol=2)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     0 1 1]'
+
+    TetGen.facetlist!(input,[[1,2,3],
+                             [4,5,6],
+                             [1,2,5,4],
+                             [2,3,6,5],
+                             [3,1,4,6]])
+
+    tetrahedralize(input, "pQa$(vol)")
+end
+
+"""
+   prism(;vol1=0.01, vol2=0.2)
+
+Tetrahedralization of a prism with two regions with different tet volumes
+"""
+function material_prism(;vol1=0.01, vol2=0.1)
+    input=TetGen.RawTetGenIO{Cdouble}()
+
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     0 1 1;
+                     0 0 2;  
+                     1 0 2;
+                     0 1 2]'
+
+    
+    TetGen.facetlist!(input,[[1,2,3],
+                             [7,8,9],
+                             [1,2,5,4],
+                             [2,3,6,5],
+                             [3,1,4,6],
+                             [1,2,5,4].+3,
+                             [2,3,6,5].+3,
+                             [3,1,4,6].+3])
+
+    input.facetmarkerlist=[1,2,3,3,3,3,3,3]
+    input.regionlist=[0.1 0.1 0.5 1 vol1;
+                      0.1 0.1 1.5 2 vol2]'
+    
+    tetrahedralize(input, "paAqQ")
+end
+
+
+"""
+   cutprism(;vol=0.05)
+
+Tetrahedralization of a prism with  a prism cut out in the middle.
+This tests the use of facet holes.
+"""
+function cutprism(;vol=0.05)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     0 1 0;
+                     
+                     0 0 10;
+                     1 0 10;
+                     0 1 10;
+                     
+                     
+                     -1 -1 0;  # 7
+                     2 -1 0;
+                     2 2 0;
+                     -1 2 0;
+                     
+                     -1 -1 10;  # 11
+                     2 -1 10;
+                     2 2 10;
+                     -1 2 10]'
+                     
+    push!(input.facetlist,RawFacet([Cint[1, 2, 3],Cint[7, 8, 9, 10]], [0.1 0.1 0.0;]))
+    push!(input.facetlist,RawFacet([Cint[4, 5, 6],Cint[11,12,13,14]], [0.1 0.1 1.0;]))
+    push!(input.facetlist,RawFacet([Cint[1, 2, 5, 4 ]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[2, 3, 6, 5 ]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[3, 1, 4, 6 ]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[7, 8, 12,11]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[8, 9, 13,12]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[9, 10,14,13]], Array{Cdouble,2}(undef,0,0)))
+    push!(input.facetlist,RawFacet([Cint[10,7, 11,14]], Array{Cdouble,2}(undef,0,0)))
+
+    input.facetmarkerlist=[1,2,3,3,3,4,5,6,7]
+    input.regionlist=[ -0.1 -0.1 0.1 1 vol;]'
+    tetrahedralize(input, "paqAQ")
+end
+

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -1,6 +1,6 @@
 module TetGen
-using TetGen_jll
 
+using TetGen_jll
 using GeometryBasics
 using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line,
     Simplex, connect, Triangle, NSimplex, Tetrahedron,
@@ -10,7 +10,8 @@ using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line,
 using StaticArrays
 
 
-include("cppwrapper.jl")
+include("cpptetgenio.jl")
+include("jltetgenio.jl")
 include("meshes.jl")
 include("api.jl")
 

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -1,5 +1,5 @@
 module TetGen
-
+using DocStringExtensions
 using TetGen_jll
 using GeometryBasics
 using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line,
@@ -18,5 +18,8 @@ include("api.jl")
 
 
 export tetrahedralize
+export RawTetGenIO, facetlist!, RawFacet
+export numberofpoints,numberoftetrahedra,numberoftrifaces,numberofedges
+export volumemesh,surfacemesh
 
 end # module

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -12,6 +12,7 @@ using StaticArrays
 
 include("cpptetgenio.jl")
 include("jltetgenio.jl")
+include("rawtetgenio.jl")
 include("meshes.jl")
 include("api.jl")
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,5 +1,5 @@
 function voronoi(points::Vector{Point{3, T}}) where T <: AbstractFloat
-    result = tetrahedralize(TetgenIO(points), "Qw")
+    result = tetrahedralize(JLTetGenIO(points), "Qw")
     Mesh{Triangle}(result)
 end
 
@@ -12,14 +12,14 @@ function TetGen.tetrahedralize(
     if hasproperty(f, marker)
         push!(kw_args, :facetmarkers => getproperty(f, marker))
     end
-    tio = TetgenIO(coordinates(mesh); kw_args...)
+    tio = JLTetGenIO(coordinates(mesh); kw_args...)
     result = tetrahedralize(tio, command)
     return Mesh{Tetrahedron}(result)
 end
 
 
 function TetGen.tetrahedralize(mesh::Mesh{3, Float64, <: TetGen.Triangle}, command = "Qp")
-    tio = TetgenIO(coordinates(mesh); facets = faces(mesh))
+    tio = JLTetGenIO(coordinates(mesh); facets = faces(mesh))
     result = tetrahedralize(tio, command)
     Mesh{Tetrahedron}(result)
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,8 +1,22 @@
+"""
+$(SIGNATURES)
+
+Create voronoi diagram of point set.    
+
+Returns a mesh of triangles.
+"""
 function voronoi(points::Vector{Point{3, T}}) where T <: AbstractFloat
     result = tetrahedralize(JLTetGenIO(points), "Qw")
     Mesh{Triangle}(result)
 end
 
+
+"""
+$(SIGNATURES)
+
+Tetrahedralize a mesh of polygons with optimal facet markers.
+Returns a mesh of tetrahdra.
+"""
 function TetGen.tetrahedralize(
         mesh::Mesh{3, Float64, <: TetGen.Ngon}, command = "Qp";
         marker = :markers
@@ -18,6 +32,12 @@ function TetGen.tetrahedralize(
 end
 
 
+"""
+$(SIGNATURES)
+
+Tetrahedralize a domain described by a mesh of triangles.
+Returns a mesh of tetrahdra.
+"""
 function TetGen.tetrahedralize(mesh::Mesh{3, Float64, <: TetGen.Triangle}, command = "Qp")
     tio = JLTetGenIO(coordinates(mesh); facets = faces(mesh))
     result = tetrahedralize(tio, command)

--- a/src/cpptetgenio.jl
+++ b/src/cpptetgenio.jl
@@ -1,0 +1,61 @@
+struct CPolygon
+  vertexlist::Ptr{Cint}
+  numberofvertices::Cint
+end
+
+struct CFacet{T}
+  polygonlist::Ptr{CPolygon}
+  numberofpolygons::Cint
+  holelist::Ptr{T}
+  numberofholes::Cint
+end
+
+
+struct CPPTetGenIO{T}
+    firstnumber::Cint # 0 or 1, default 0.
+    mesh_dim::Cint # must be 3.
+
+    pointlist::Ptr{T}
+    pointattributelist::Ptr{T}
+    pointmtrlist::Ptr{T}
+
+    pointmarkerlist::Ptr{Cint}
+    numberofpoints::Cint
+    numberofpointattributes::Cint
+    numberofpointmtrs::Cint
+
+    tetrahedronlist::Ptr{Cint}
+    tetrahedronattributelist::Ptr{T}
+    tetrahedronvolumelist::Ptr{T}
+    neighborlist::Ptr{Cint}
+    numberoftetrahedra::Cint
+    numberofcorners::Cint
+    numberoftetrahedronattributes::Cint
+
+    facetlist::Ptr{CFacet{T}}
+    facetmarkerlist::Ptr{Cint}
+    numberoffacets::Cint
+
+    holelist::Ptr{T}
+    numberofholes::Cint
+
+    regionlist::Ptr{T}
+    numberofregions::Cint
+
+    facetconstraintlist::Ptr{T}
+    numberoffacetconstraints::Cint
+
+    segmentconstraintlist::Ptr{T}
+    numberofsegmentconstraints::Cint
+
+    trifacelist::Ptr{Cint}
+    trifacemarkerlist::Ptr{Cint}
+    numberoftrifaces::Cint
+
+    edgelist::Ptr{Cint}
+    edgemarkerlist::Ptr{Cint}
+    numberofedges::Cint
+end
+
+tetrahedralize(input::CPPTetGenIO{Float64}, command::String)=ccall((:tetrahedralizef64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring), input, command)
+

--- a/src/meshes.jl
+++ b/src/meshes.jl
@@ -1,7 +1,7 @@
 using GeometryBasics: Triangle, Tetrahedron, Mesh, Polytope
 
 """
-    Mesh{Tetrahedron}(result::TetgenIO)
+    Mesh{Tetrahedron}(result::JLTetGenIO)
 
 Extracts the *tetrahedral* mesh from `tetgenio`.
 Can also be called with extra information, e.g.:
@@ -11,7 +11,7 @@ Can also be called with extra information, e.g.:
     Mesh{Simplex{NDim, T, Edges, PointType}}(tetio)
 ```
 
-    Mesh{Triangle}(result::TetgenIO)
+    Mesh{Triangle}(result::JLTetGenIO)
 
 Extracts the triangular *surface* mesh from `tetgenio`.
 Can also be called with extra information, e.g.:
@@ -21,16 +21,16 @@ Can also be called with extra information, e.g.:
     Mesh{Ngon{NDim, T, 3, PointType}}(tetio)
 ```
 """
-function GeometryBasics.Mesh{P}(x::TetgenIO{T}) where {P <: Polytope{N, T} where {N, T}, T}
+function GeometryBasics.Mesh{P}(x::JLTetGenIO{T}) where {P <: Polytope{N, T} where {N, T}, T}
     Mesh{Polytope(P, Point{3, T})}(x)
 end
 
 
-function GeometryBasics.Mesh{TetrahedronP{ET, P}}(x::TetgenIO) where {ET, P}
+function GeometryBasics.Mesh{TetrahedronP{ET, P}}(x::JLTetGenIO) where {ET, P}
     Mesh(convert(Vector{P}, x.points), x.tetrahedra)
 end
 
 
-function GeometryBasics.Mesh{TriangleP{3, ET, P}}(x::TetgenIO) where {ET, P}
+function GeometryBasics.Mesh{TriangleP{3, ET, P}}(x::JLTetGenIO) where {ET, P}
     Mesh(convert(Vector{P}, x.points), x.trifaces)
 end

--- a/src/rawtetgenio.jl
+++ b/src/rawtetgenio.jl
@@ -1,0 +1,379 @@
+"""
+A  "polygon"  describes  a  simple  polygon  (no  holes).  It  is  not
+necessarily convex. Each polygon contains a number of corners (points)
+and the same number of sides  (edges).  The points of the polygon must
+be given in either counterclockwise or clockwise order and they form a
+ring, so every two consecutive points forms an edge of the polygon.
+"""
+struct RawPolygon
+    vertexlist::Array{Cint,2}
+end
+
+"""
+A "facet" describes a polygonal region possibly with holes, edges, and
+points floating in it.  Each facet  consists of a list of polygons and
+a list of hole points (which lie strictly inside holes).
+"""
+struct RawFacet{T}
+    polygonlist::Array{RawPolygon,1}
+    holelist::Array{T,2}
+end
+
+
+mutable struct RawTetGenIO{T}
+    """
+    'pointlist':  An array of point coordinates.  The first point's x
+     coordinate is at index [0] and its y coordinate at index [1], its
+     z coordinate is at index [2], followed by the coordinates of the
+     remaining points.  Each point occupies three REALs. 
+    """
+    pointlist::Array{T,2}
+
+    """
+    'pointattributelist':  An array of point attributes.  Each point's
+    attributes occupy 'numberofpointattributes' REALs.
+    """
+    pointattributelist::Array{T,2}
+
+    """
+    'pointmtrlist': An array of metric tensors at points. Each point'
+     tensor occupies 'numberofpointmtr' REALs.
+    """
+    pointmtrlist::Array{T,2}
+
+    """
+    'pointmarkerlist':  An array of point markers; one integer per point.
+    """
+    pointmarkerlist::Array{T,2}
+
+    """
+    'tetrahedronlist':  An array of tetrahedron corners.  The first 
+    tetrahedron's first corner is at index [0], followed by its other 
+    corners, followed by six nodes on the edges of the tetrahedron if the
+    second order option (-o2) is applied. Each tetrahedron occupies
+    'numberofcorners' ints.  The second order nodes are ouput only. 
+    """
+    tetrahedronlist::Array{Cint,2}
+
+    """
+    'tetrahedronattributelist':  An array of tetrahedron attributes.  Each
+    tetrahedron's attributes occupy 'numberoftetrahedronattributes' REALs.
+    """
+    tetrahedronattributelist::Array{T,2}
+
+    """
+    'tetrahedronvolumelist':  An array of constraints, i.e. tetrahedron's
+     volume; one REAL per element.  Input only.
+    """
+    tetrahedronvolumelist::Array{T,1}
+
+    """
+    'neighborlist':  An array of tetrahedron neighbors; 4 ints per element. 
+     Output only.
+    """
+    neighborlist::Array{Cint,2}
+
+    """
+    'facetlist':  An array of facets.  Each entry is a structure of facet.
+    """
+    facetlist::Array{RawFacet{T},1}
+
+    """
+    'facetmarkerlist':  An array of facet markers; one int per facet.
+    """
+    facetmarkerlist::Array{Cint,1}
+
+    """
+    'holelist':  An array of holes (in volume).  Each hole is given by a
+     seed (point) which lies strictly inside it. The first seed's x, y and z
+     coordinates are at indices [0], [1] and [2], followed by the
+     remaining seeds.  Three REALs per hole. 
+    """
+    holelist::Array{T,2}
+
+    """
+     'regionlist': An array of regions (subdomains).  Each region is given by
+     a seed (point) which lies strictly inside it. The first seed's x, y and
+     z coordinates are at indices [0], [1] and [2], followed by the regional
+     attribute at index [3], followed by the maximum volume at index [4]. 
+     Five REALs per region.
+
+      Note that each regional attribute is used only if you select the 'A'
+     switch, and each volume constraint is used only if you select the
+     'a' switch (with no number following).
+    """
+    regionlist::Array{T,2}
+
+    """
+    'facetconstraintlist':  An array of facet constraints.  Each constraint
+    specifies a maximum area bound on the subfaces of that facet.  The
+    first facet constraint is given by a facet marker at index [0] and its
+    maximum area bound at index [1], followed by the remaining facet con-
+    straints. Two REALs per facet constraint.  Note: the facet marker is
+    actually an integer.
+    """
+    facetconstraintlist::Array{T,2}
+
+    """
+    'segmentconstraintlist': An array of segment constraints. Each constraint 
+    specifies a maximum length bound on the subsegments of that segment.
+    The first constraint is given by the two endpoints of the segment at
+    index [0] and [1], and the maximum length bound at index [2], followed
+    by the remaining segment constraints.  Three REALs per constraint. 
+    Note the segment endpoints are actually integers.
+    """
+    segmentconstraintlist::Array{T,2}
+
+    """
+    'trifacelist':  An array of face (triangle) corners.  The first face's
+    three corners are at indices [0], [1] and [2], followed by the remaining
+    faces.  Three ints per face.
+    """
+    trifacelist::Array{Cint,2}
+
+    """
+    'trifacemarkerlist':  An array of face markers; one int per face.
+    """
+    trifacemarkerlist::Array{Cint,1}
+
+    """
+    'edgelist':  An array of edge endpoints.  The first edge's endpoints
+    are at indices [0] and [1], followed by the remaining edges.
+    Two ints per edge.
+    """
+    edgelist::Array{Cint,2}
+
+    """
+    'edgemarkerlist':  An array of edge markers; one int per edge.
+    """
+    edgemarkerlist::Array{Cint}
+end
+
+function RawTetGenIO{T}(;
+                        pointlist=Array{T,2}(undef,0,0),
+                        pointattributelist=Array{T,2}(undef,0,0),
+                        pointmtrlist=Array{T,2}(undef,0,0),
+                        pointmarkerlist=Array{T,2}(undef,0,0),
+                        tetrahedronlist=Array{Cint,2}(undef,0,0),
+                        tetrahedronattributelist=Array{T,2}(undef,0,0),
+                        tetrahedronvolumelist=Array{T,1}(undef,0),
+                        neighborlist=Array{Cint,2}(undef,0,0),
+                        facetlist=Array{RawFacet{T},1}(undef,0),
+                        facetmarkerlist=Array{Cint,1}(undef,0),
+                        holelist=Array{T,2}(undef,0,0),
+                        regionlist=Array{T,2}(undef,0,0),
+                        facetconstraintlist=Array{T,2}(undef,0,0),
+                        segmentconstraintlist=Array{T,2}(undef,0,0),
+                        trifacelist=Array{Cint,2}(undef,0,0),
+                        trifacemarkerlist=Array{Cint,1}(undef,0),
+                        edgelist=Array{Cint,2}(undef,0,0),
+                        edgemarkerlist=Array{Cint}(undef,0)
+                        ) where T
+    
+    RawTetGenIO{T}(
+        pointlist,
+        pointattributelist,
+        pointmtrlist,
+        pointmarkerlist,
+        tetrahedronlist,
+        tetrahedronattributelist,
+        tetrahedronvolumelist,
+        neighborlist,
+        facetlist,
+        facetmarkerlist,
+        holelist,
+        regionlist,
+        facetconstraintlist,
+        segmentconstraintlist,
+        trifacelist,
+        trifacemarkerlist,
+        edgelist,
+        edgemarkerlist
+    )
+end
+
+function Base.show(io::IO, tio::RawTetGenIO)
+    nonempty(a)=size(a,ndims(a))>0
+    println(io,"RawTetGenIO(")
+    for name in fieldnames(typeof(tio))
+        a=getfield(tio,name)
+        if nonempty(a)
+            print(io,"$(name)=")
+            print(io,a)
+            println(io,",")
+        end
+    end
+    println(io,")")
+end
+
+
+function CPPTetGenIO(tio::RawTetGenIO{T}) where T
+    
+    # Set dummy defaults
+    firstnumber = zero(Cint) 
+    mesh_dim = zero(Cint) 
+    
+    pointlist = C_NULL
+    pointattributelist = C_NULL
+    pointmtrlist = C_NULL
+
+    pointmarkerlist = C_NULL
+    numberofpoints = zero(Cint)
+    numberofpointattributes = zero(Cint)
+    numberofpointmtrs = zero(Cint)
+
+    tetrahedronlist = C_NULL
+    tetrahedronattributelist = C_NULL
+    tetrahedronvolumelist = C_NULL
+
+    neighborlist = C_NULL
+    numberoftetrahedra = zero(Cint)
+    numberofcorners = zero(Cint)
+    numberoftetrahedronattributes = zero(Cint)
+
+    facetlist =  C_NULL
+    facetmarkerlist = C_NULL
+    numberoffacets = zero(Cint)
+
+    holelist = C_NULL
+    numberofholes = zero(Cint)
+
+    regionlist = C_NULL
+    numberofregions = zero(Cint)
+
+    facetconstraintlist = C_NULL
+    numberoffacetconstraints = zero(Cint)
+
+    segmentconstraintlist = C_NULL
+    numberofsegmentconstraints = zero(Cint)
+
+    trifacelist = C_NULL
+    trifacemarkerlist = C_NULL
+    numberoftrifaces = zero(Cint)
+
+    edgelist = C_NULL
+    edgemarkerlist = C_NULL
+    numberofedges = zero(Cint)
+
+    # Override defaults
+    numberofpoints=size(tio.pointlist,2)
+    @assert numberofpoints>zero(Cint)
+    @assert size(tio.pointlist,1) == 3
+    pointlist=pointer(tio.pointlist)
+
+    numberofpointattributes=size(tio.pointattributelist,1)
+    if numberofpointattributes>0
+        @assert size(tio.pointattributelist,2)==numberofpoints
+        pointattributelist=pointer(tio.pointattributelist)
+    end
+
+    numberofpointmtrs=size(tio.pointmtrlist,1)
+    if numberofpointmtrs>0
+        @assert size(tio.pointmtrlist,2)==numberofpoints
+        pointmtrlist=pointer(tio.pointmtrlist)
+    end
+    
+    numberoftetrahedra=size(tio.tetrahedronlist,2)
+    if numberoftetrahedra>0
+        tetrahedronlist=pointer(tio.tetrahedronlist)
+        numberoftetrahedronattributes=size(tio.tetrahedronattributelist,1)
+        numberofcorners=size(tio.tetrahedronlist,1)
+        if numberoftetrahedronattributes>0
+            @assert size(tio.tetrahedronattributelist,2)==numberoftetrahedra
+            tetrahedronattributes=pointer(tio.tetrahedronattributes)
+        end
+        if size(tio.tetrahedronvolumelist,1)>0
+            @assert size(tio.tetrahedronvolumelist,1)==numberoftetrahedra
+            tetrahedronvolumelist=pointer(tio.tetrahedronvolumelist)
+        end
+    end
+
+    numberoffacets=size(tio.facetlist,2)
+    if numberoffacets>0
+        facetlist=pointer(tio.facetlist)
+    end
+    if size(tio.facetmarkerlist,1)>0
+        @assert size(tio.facetmarkerlist,1)==numberoffacets
+        facetmarkerlist=pointer(tio.facetmarkerlist)
+    end
+
+    numberofholes=size(tio.holelist,2)
+    if numberofholes>0
+        @assert size(tio.holelist,1)==3
+        holelist=pointer(tio.holelist)
+    end
+    
+    numberofregions=size(tio.regionlist,2)
+    if numberofregions>0
+        @assert size(tio.regionlist,1)==5 # coord+attribute + volume
+        regionlist=pointer(tio.regionlist)
+    end
+
+    if size(tio.facetconstraintlist,2)>0
+        @assert size(tio.facetconstraintlist,1) == 2
+        numberoffacetconstraints=size(tio.facetconstraintlist,2)
+        facetconstraintlist=pointer(tio.facetconstraintlist)
+    end
+
+    if size(tio.segmentconstraintlist,2)>0
+        @assert size(tio.segmentconstraintlist,1) == 3
+        numberofsegmentconstraints=size(tio.segmentconstraintlist,2)
+        segmentconstraintlist=pointer(tio.segmentconstraintlist)
+    end
+
+    if size(tio.trifacelist,2)>0
+        @assert size(tio.trifacelist,1) == 3
+        numberoftrifaces=size(tio.trifacelist,2)
+        trifacelist=pointer(tio.trifacelist)
+        if size(tio.trifacemarkerlist,1) > 0
+            @assert size(tio.trifacemarkerlist,1) == numberoftrifaces
+            trifacemarkerlist=pointer(tio.trifacemarkerlist)
+        end            
+    end
+    
+    if size(tio.edgelist,2)>0
+        @assert size(tio.edgelist,1) == 2
+        numberofedges=size(tio.edgelist,2)
+        edgelist=pointer(tio.edgelist)
+        if size(tio.edgemarkerlist,1) > 0
+            @assert size(tio.edgemarkerlist,1) == numberofedges
+            edgemarkerlist=pointer(tio.edgemarkerlist)
+        end            
+    end
+    
+    
+    # Convert
+    CPPTetGenIO{T}(firstnumber,
+                   mesh_dim,
+                   pointlist,
+                   pointattributelist,
+                   pointmtrlist,
+                   pointmarkerlist,
+                   numberofpoints,
+                   numberofpointattributes,
+                   numberofpointmtrs,
+                   tetrahedronlist,
+                   tetrahedronattributelist,
+                   tetrahedronvolumelist,
+                   neighborlist,
+                   numberoftetrahedra,
+                   numberofcorners,
+                   numberoftetrahedronattributes,
+                   facetlist,
+                   facetmarkerlist,
+                   numberoffacets,
+                   holelist,
+                   numberofholes,
+                   regionlist,
+                   numberofregions,
+                   facetconstraintlist,
+                   numberoffacetconstraints,
+                   segmentconstraintlist,
+                   numberofsegmentconstraints,
+                   trifacelist,
+                   trifacemarkerlist,
+                   numberoftrifaces,
+                   edgelist,
+                   edgemarkerlist,
+                   numberofedges)
+end

--- a/src/rawtetgenio.jl
+++ b/src/rawtetgenio.jl
@@ -1,69 +1,89 @@
 """
-A  "polygon"  describes  a  simple  polygon  (no  holes).  It  is  not
-necessarily convex. Each polygon contains a number of corners (points)
-and the same number of sides  (edges).  The points of the polygon must
-be given in either counterclockwise or clockwise order and they form a
-ring, so every two consecutive points forms an edge of the polygon.
-"""
-struct RawPolygon
-    vertexlist::Array{Cint,2}
-end
+$(TYPEDEF)
 
-"""
-A "facet" describes a polygonal region possibly with holes, edges, and
-points floating in it.  Each facet  consists of a list of polygons and
-a list of hole points (which lie strictly inside holes).
+A complex facet as part to the input to TetGen.
+
+$(TYPEDFIELDS)
 """
 struct RawFacet{T}
-    polygonlist::Array{RawPolygon,1}
+    """
+    Polygons given as arrays of indices which point into the 
+    pointlist array describing the input points.
+    """
+    polygonlist::Array{Array{Cint,1},1}
+
+    """
+    Array of points given by their coordinates
+    marking polygons describing holes in the facet.
+    """
     holelist::Array{T,2}
 end
 
 
+"""
+$(TYPEDEF)
+
+A  structure for  transferring  data  into and  out  of TetGen's
+internal representation.
+                                                                           
+The input of TetGen is either a 3D point set, or a 3D piecewise linear
+complex (PLC), or  a tetrahedral mesh.  Depending on  the input object
+and the specified  options, the output of TetGen is  either a Delaunay
+(or weighted Delaunay) tetrahedralization, or a constrained (Delaunay)
+tetrahedralization, or a quality tetrahedral mesh.
+                                                                           
+A piecewise  linear complex  (PLC) represents  a 3D  polyhedral domain
+with  possibly internal  boundaries(subdomains). It  is introduced  in
+[Miller  et al,  1996].   Basically  it is  a  set  of "cells",  i.e.,
+vertices, edges, polygons, and polyhedra,  and the intersection of any
+two of its cells is the union of other cells of it.
+                                                                           
+The 'RawTetGenIO' structure  is a collection of arrays  of data, i.e.,
+points, facets, tetrahedra,  and so forth. All data  are compatible to
+the representation in C++ and can be used without copying.
+
+
+$(TYPEDFIELDS)
+"""
 mutable struct RawTetGenIO{T}
     """
-    'pointlist':  An array of point coordinates.  The first point's x
-     coordinate is at index [0] and its y coordinate at index [1], its
-     z coordinate is at index [2], followed by the coordinates of the
-     remaining points.  Each point occupies three REALs. 
+    'pointlist':  Array of point coordinates with `size(pointlist,1)==3`.
     """
     pointlist::Array{T,2}
 
     """
-    'pointattributelist':  An array of point attributes.  Each point's
-    attributes occupy 'numberofpointattributes' REALs.
+    'pointattributelist':  Array of point attributes. The number of 
+     attributes per point is determined by  `size(pointattributelist,1)`
     """
     pointattributelist::Array{T,2}
 
     """
-    'pointmtrlist': An array of metric tensors at points. Each point'
-     tensor occupies 'numberofpointmtr' REALs.
+    'pointmtrlist': An array of metric tensors at points.
     """
     pointmtrlist::Array{T,2}
 
     """
     'pointmarkerlist':  An array of point markers; one integer per point.
     """
-    pointmarkerlist::Array{T,2}
+    pointmarkerlist::Array{Cint,1}
 
-    """
-    'tetrahedronlist':  An array of tetrahedron corners.  The first 
-    tetrahedron's first corner is at index [0], followed by its other 
-    corners, followed by six nodes on the edges of the tetrahedron if the
-    second order option (-o2) is applied. Each tetrahedron occupies
-    'numberofcorners' ints.  The second order nodes are ouput only. 
+    """ 'tetrahedronlist': An array of tetrahedron corners represented
+    by indices of points in `pointlist`. Unless option `-o2` is given,
+    one has  `size(tetrahedronlist,1)==4`, i.e. each  column describes
+    the    four     corners    of    a     tetrahedron.     Otherwise,
+    `size(tetrahedronlist,1)==10` and the 4  corners are followed by 6
+    edge midpoints.  
     """
     tetrahedronlist::Array{Cint,2}
 
     """
-    'tetrahedronattributelist':  An array of tetrahedron attributes.  Each
-    tetrahedron's attributes occupy 'numberoftetrahedronattributes' REALs.
+    'tetrahedronattributelist':  An array of tetrahedron attributes.
     """
     tetrahedronattributelist::Array{T,2}
 
     """
     'tetrahedronvolumelist':  An array of constraints, i.e. tetrahedron's
-     volume; one REAL per element.  Input only.
+     volume;  Input only. This can be used for triggering local refinement.
     """
     tetrahedronvolumelist::Array{T,1}
 
@@ -85,20 +105,17 @@ mutable struct RawTetGenIO{T}
 
     """
     'holelist':  An array of holes (in volume).  Each hole is given by a
-     seed (point) which lies strictly inside it. The first seed's x, y and z
-     coordinates are at indices [0], [1] and [2], followed by the
-     remaining seeds.  Three REALs per hole. 
+     point which lies strictly inside it.
     """
     holelist::Array{T,2}
 
     """
      'regionlist': An array of regions (subdomains).  Each region is given by
-     a seed (point) which lies strictly inside it. The first seed's x, y and
-     z coordinates are at indices [0], [1] and [2], followed by the regional
-     attribute at index [3], followed by the maximum volume at index [4]. 
-     Five REALs per region.
+     a seed (point) which lies strictly inside it. For each column,
+     the point coordinates ade  at indices [1], [2] and [3], followed by the regional
+     attribute at index [4], followed by the maximum volume at index [5]. 
 
-      Note that each regional attribute is used only if you select the 'A'
+     ote that each regional attribute is used only if you select the 'A'
      switch, and each volume constraint is used only if you select the
      'a' switch (with no number following).
     """
@@ -106,10 +123,9 @@ mutable struct RawTetGenIO{T}
 
     """
     'facetconstraintlist':  An array of facet constraints.  Each constraint
-    specifies a maximum area bound on the subfaces of that facet.  The
-    first facet constraint is given by a facet marker at index [0] and its
-    maximum area bound at index [1], followed by the remaining facet con-
-    straints. Two REALs per facet constraint.  Note: the facet marker is
+    specifies a maximum area bound on the subfaces of that facet.  Each column
+    contains  a facet marker at index [1] and its
+    maximum area bound at index [2]. Note: the facet marker is
     actually an integer.
     """
     facetconstraintlist::Array{T,2}
@@ -117,17 +133,14 @@ mutable struct RawTetGenIO{T}
     """
     'segmentconstraintlist': An array of segment constraints. Each constraint 
     specifies a maximum length bound on the subsegments of that segment.
-    The first constraint is given by the two endpoints of the segment at
-    index [0] and [1], and the maximum length bound at index [2], followed
-    by the remaining segment constraints.  Three REALs per constraint. 
+    Each columb consists of the  two endpoints of the segment at
+    index [1] and [2], and the maximum length bound at index [3].
     Note the segment endpoints are actually integers.
     """
     segmentconstraintlist::Array{T,2}
 
     """
-    'trifacelist':  An array of face (triangle) corners.  The first face's
-    three corners are at indices [0], [1] and [2], followed by the remaining
-    faces.  Three ints per face.
+    'trifacelist':  An array of face (triangle) corners.
     """
     trifacelist::Array{Cint,2}
 
@@ -137,23 +150,26 @@ mutable struct RawTetGenIO{T}
     trifacemarkerlist::Array{Cint,1}
 
     """
-    'edgelist':  An array of edge endpoints.  The first edge's endpoints
-    are at indices [0] and [1], followed by the remaining edges.
-    Two ints per edge.
+    'edgelist':  An array of edge endpoints.
     """
     edgelist::Array{Cint,2}
 
     """
-    'edgemarkerlist':  An array of edge markers; one int per edge.
+    'edgemarkerlist':  An array of edge markers.
     """
     edgemarkerlist::Array{Cint}
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Create RawTetGenIO structure with empty data.
+"""
 function RawTetGenIO{T}(;
                         pointlist=Array{T,2}(undef,0,0),
                         pointattributelist=Array{T,2}(undef,0,0),
                         pointmtrlist=Array{T,2}(undef,0,0),
-                        pointmarkerlist=Array{T,2}(undef,0,0),
+                        pointmarkerlist=Array{Cint,1}(undef,0),
                         tetrahedronlist=Array{Cint,2}(undef,0,0),
                         tetrahedronattributelist=Array{T,2}(undef,0,0),
                         tetrahedronvolumelist=Array{T,1}(undef,0),
@@ -169,7 +185,6 @@ function RawTetGenIO{T}(;
                         edgelist=Array{Cint,2}(undef,0,0),
                         edgemarkerlist=Array{Cint}(undef,0)
                         ) where T
-    
     RawTetGenIO{T}(
         pointlist,
         pointattributelist,
@@ -192,13 +207,29 @@ function RawTetGenIO{T}(;
     )
 end
 
+
+
+
 function Base.show(io::IO, tio::RawTetGenIO)
     nonempty(a)=size(a,ndims(a))>0
     println(io,"RawTetGenIO(")
+    print(io,"numberofpoints=")
+    print(io,numberofpoints(tio))
+    println(io,",")
+    print(io,"numberofedges=")
+    print(io,numberofedges(tio))
+    println(io,",")
+    print(io,"numberoftrifaces=")
+    print(io,numberoftrifaces(tio))
+    println(io,",")
+    print(io,"numberoftetrahedra=")
+    print(io,numberoftetrahedra(tio))
+    println(io,",")
     for name in fieldnames(typeof(tio))
+#        a=round.(getfield(tio,name),sigdigits=3)'
         a=getfield(tio,name)
         if nonempty(a)
-            print(io,"$(name)=")
+            print(io,"$(name)'=")
             print(io,a)
             println(io,",")
         end
@@ -206,13 +237,44 @@ function Base.show(io::IO, tio::RawTetGenIO)
     println(io,")")
 end
 
+"""
+    $(TYPEDSIGNATURES)
+    Set list of input facets from AbstractMatrix desribing polygons of the same
+    size (e.g. triangles)
+"""
+function facetlist!(tio::RawTetGenIO{T}, facets::AbstractMatrix) where {T}
+    numberoffacets=size(facets,2)
+    tio.facetlist=Array{RawFacet{T},1}(undef,numberoffacets)
+    for ifacet=1:numberoffacets
+        tio.facetlist[ifacet]=RawFacet{T}([Vector{Cint}(facets[:,ifacet])],Array{T,2}(undef,0,0))
+    end
+    tio
+end
 
+"""
+    $(TYPEDSIGNATURES)
+    Set list of input facets from a vector of polygons of different size
+"""
+function facetlist!(tio::RawTetGenIO{T}, facets::Vector) where {T}
+    numberoffacets=size(facets,1)
+    tio.facetlist=Array{RawFacet{T},1}(undef,numberoffacets)
+    for ifacet=1:numberoffacets
+        tio.facetlist[ifacet]=RawFacet{T}([Vector{Cint}(facets[ifacet])],Array{T,2}(undef,0,0))
+    end
+    tio
+end
+
+
+
+#
+# Create CPPTetGenIO from RawTetGenIO
+#
 function CPPTetGenIO(tio::RawTetGenIO{T}) where T
     
-    # Set dummy defaults
-    firstnumber = zero(Cint) 
-    mesh_dim = zero(Cint) 
+    firstnumber = 1
+    mesh_dim = 3
     
+    # Set dummy defaults
     pointlist = C_NULL
     pointattributelist = C_NULL
     pointmtrlist = C_NULL
@@ -221,16 +283,16 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
     numberofpoints = zero(Cint)
     numberofpointattributes = zero(Cint)
     numberofpointmtrs = zero(Cint)
-
+    
     tetrahedronlist = C_NULL
     tetrahedronattributelist = C_NULL
     tetrahedronvolumelist = C_NULL
-
+    
     neighborlist = C_NULL
     numberoftetrahedra = zero(Cint)
     numberofcorners = zero(Cint)
     numberoftetrahedronattributes = zero(Cint)
-
+    
     facetlist =  C_NULL
     facetmarkerlist = C_NULL
     numberoffacets = zero(Cint)
@@ -255,18 +317,23 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
     edgemarkerlist = C_NULL
     numberofedges = zero(Cint)
 
+    # these need to be returned in order
+    # to prevent their content  from being garbage collected
+    facetlist_array=Array{CFacet{T},1}(undef,numberoffacets)
+    polygonlist_array=Array{Array{CPolygon,1},1}(undef,0)
+    
     # Override defaults
     numberofpoints=size(tio.pointlist,2)
     @assert numberofpoints>zero(Cint)
     @assert size(tio.pointlist,1) == 3
     pointlist=pointer(tio.pointlist)
-
+    
     numberofpointattributes=size(tio.pointattributelist,1)
     if numberofpointattributes>0
         @assert size(tio.pointattributelist,2)==numberofpoints
         pointattributelist=pointer(tio.pointattributelist)
     end
-
+    
     numberofpointmtrs=size(tio.pointmtrlist,1)
     if numberofpointmtrs>0
         @assert size(tio.pointmtrlist,2)==numberofpoints
@@ -280,18 +347,30 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
         numberofcorners=size(tio.tetrahedronlist,1)
         if numberoftetrahedronattributes>0
             @assert size(tio.tetrahedronattributelist,2)==numberoftetrahedra
-            tetrahedronattributes=pointer(tio.tetrahedronattributes)
+            tetrahedronattributelist=pointer(tio.tetrahedronattributelist)
         end
         if size(tio.tetrahedronvolumelist,1)>0
             @assert size(tio.tetrahedronvolumelist,1)==numberoftetrahedra
             tetrahedronvolumelist=pointer(tio.tetrahedronvolumelist)
         end
     end
-
-    numberoffacets=size(tio.facetlist,2)
+    
+    numberoffacets=size(tio.facetlist,1)
     if numberoffacets>0
-        facetlist=pointer(tio.facetlist)
+        for ifacet=1:numberoffacets
+            facet=tio.facetlist[ifacet]
+            numberofpolygons=size(facet.polygonlist,1)
+            polygonlist=Array{CPolygon,1}(undef, numberofpolygons)
+            for ipolygon=1:numberofpolygons
+                polygonlist[ipolygon]=CPolygon(pointer(facet.polygonlist[ipolygon]),size(facet.polygonlist[ipolygon],1))
+            end
+            numberofholes=size(facet.holelist,2)
+            push!(polygonlist_array,polygonlist)
+            push!(facetlist_array,CFacet(pointer(polygonlist),Cint(numberofpolygons),pointer(facet.holelist),Cint(numberofholes)))
+        end
+        facetlist=pointer(facetlist_array)
     end
+    
     if size(tio.facetmarkerlist,1)>0
         @assert size(tio.facetmarkerlist,1)==numberoffacets
         facetmarkerlist=pointer(tio.facetmarkerlist)
@@ -342,7 +421,7 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
     end
     
     
-    # Convert
+    # Create struct
     CPPTetGenIO{T}(firstnumber,
                    mesh_dim,
                    pointlist,
@@ -375,5 +454,212 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
                    numberoftrifaces,
                    edgelist,
                    edgemarkerlist,
-                   numberofedges)
+                   numberofedges),facetlist_array, polygonlist_array
 end
+
+
+
+#
+# Create  RawTetGenIO from CPPTetGenIO
+#
+function RawTetGenIO(ctio::CPPTetGenIO{T}) where T
+
+    tio=RawTetGenIO{T}()
+    if ctio.numberofpoints>0 && ctio.pointlist!=C_NULL
+        tio.pointlist = convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointlist, (3,Int(ctio.numberofpoints)), own=true))
+    end
+    if ctio.numberofpointattributes>0  && ctio.pointattributelist!=C_NULL
+        tio.pointattributelist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointattributelistlist, (Int(ctio.numberofpointattributes),Int(ctio.numberofpoints)), own=true))
+    end
+    if ctio.numberofpointmtrs>0  && ctio.pointmtrlist!=C_NULL
+        tio.pointmtrlist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointmtrlistlist, (Int(ctio.numberofpointmtrs),Int(ctio.numberofpoints)), own=true))
+    end
+    if ctio.pointmarkerlist!=C_NULL
+        tio.pointmarkerlist=convert(Array{Cint,1}, Base.unsafe_wrap(Array, ctio.pointmarkerlist, (Int(ctio.numberofpoints)), own=true))
+    end
+    @assert ctio.numberofcorners==4
+    if ctio.numberoftetrahedra>0 && ctio.tetrahedronlist!=C_NULL
+        tio.tetrahedronlist=convert(Array{Cint,2}, Base.unsafe_wrap(Array, ctio.tetrahedronlist, (4,Int(ctio.numberoftetrahedra)), own=true))
+    end
+    if ctio.numberoftetrahedronattributes>0  && ctio.tetrahedronattributelist!=C_NULL
+        tio.tetrahedronattributelist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.tetrahedronattributelist, (Int(ctio.numberoftetrahedronattributes),Int(ctio.numberoftetrahedra)), own=true))
+    end
+    if ctio.tetrahedronvolumelist!=C_NULL 
+        tio.tetrahedronvolumelist=convert(Array{T,1}, Base.unsafe_wrap(Array, ctio.tetrahedronvolumelist, (Int(ctio.numberoftetrahedra)), own=true))
+    end
+    if ctio.numberoftetrahedra>0 && ctio.neighborlist!=C_NULL
+        tio.neighborlist=convert(Array{Cint,2}, Base.unsafe_wrap(Array, ctio.neighborlist, (4,Int(ctio.numberoftetrahedra)), own=true))
+    end
+
+    
+    # Essentially, facetlist appears to be used only during input, so we can skip the
+    # conversion here (and increase test coverage...).
+    # The created facets are in the trifacelist further down this code.
+    # When uncommenting, test...
+    # if ctio.numberoffacets>0
+    #     facetlist=convert(Array{CFacet,1}, Base.unsafe_wrap(Array, ctio.facetlist, (Int(ctio.numberoffacets)), own=true))
+    #     tio.facetlist=Array{RawFacet{T},1}(undef,ctio.numberoffacets)
+    #     for ifacet=1:numberoffacets
+    #         # Possibly this is copied from the input, so we
+    #         # might not want to own the pointers here.
+    #         facet=facetlist[i]
+    #         polygonlist=Array{Array{Cint,1},1}(undef,facet.numberofpolygons)
+    #         for ipolygon=1:facet.numberofpolygons
+    #             polygonlist[ipolygon]=convert(Array{Cint,1},Base.unsafe_wrap(Array, facet.polygonlist[i].vertexlist , (Int(facet.polygonlist[i].numberofvertices)), own=true))
+    #         end
+    #         holelist=convert(Array{T,1},Base.unsafe_wrap(Array, facet.holelist , (Int(facet.numberofholes)), own=true))
+    #         tio.facetlist=RawFacet{T}(polygonlist,holelist)
+    #     end
+    #     if ctio.facetmarkerlist != C_NULL
+    #         tio.facetmarkerlist=convert(Array{Cint,1}, Base.unsafe_wrap(Array, ctio.facetmarkerlist, (Int(ctio.numberoffacets)), own=true))
+    #     end
+    # end
+
+    # Usually, this ctio comes from the output of tetrahedralize(). In this case, the holelist pointer is copied from the input
+    # so we would get a double free corruption if we own it here.
+    if ctio.numberofholes>0 && ctio.holelist!=C_NULL
+        tio.holelist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.holelist, (3,Int(ctio.numberofholes)), own=false))
+    end
+    
+    # Usually, this ctio comes from the output of tetrahedralize(). In this case, the regionlist pointer is copied from the input
+    # so we would get a double free corruption if we own it here.
+    if ctio.numberofregions>0  && ctio.regionlist!=C_NULL
+        tio.regionlist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.regionlist, (5,Int(ctio.numberofregions)), own=false))
+    end
+
+    # own ? May be comes from input
+    if ctio.numberoffacetconstraints>0
+        tio.facetconstraintlist=convert(Array{T,1}, Base.unsafe_wrap(Array, ctio.facetconstraintlist, (2,ctio.numberoffacetconstraints), own=false))
+    end
+    
+    # own ? May be comes from input
+    if ctio.numberofsegmentconstraints>0
+        tio.segmentconstraintlist=convert(Array{T,1}, Base.unsafe_wrap(Array, ctio.segmentconstraintlist, (3,ctio.numberofsegmentconstraints), own=false))
+    end
+
+    
+    if ctio.numberoftrifaces>0  && ctio.trifacelist!=C_NULL && ctio.trifacemarkerlist!=C_NULL
+        tio.trifacelist=convert(Array{Cint,2}, Base.unsafe_wrap(Array, ctio.trifacelist, (3,Int(ctio.numberoftrifaces)), own=true))
+        tio.trifacemarkerlist=convert(Array{Cint,1}, Base.unsafe_wrap(Array, ctio.trifacemarkerlist, (Int(ctio.numberoftrifaces)), own=true))
+    end
+
+    if ctio.numberofedges>0  && ctio.edgelist!=C_NULL && ctio.edgemarkerlist!=C_NULL
+        tio.edgelist=convert(Array{Cint,2}, Base.unsafe_wrap(Array, ctio.edgelist, (2,Int(ctio.numberofedges)), own=true))
+        tio.edgemarkerlist=convert(Array{Cint,1}, Base.unsafe_wrap(Array, ctio.edgemarkerlist, (Int(ctio.numberofedges)), own=true))
+    end
+
+    return tio
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Number of points in tetrahedralization
+"""
+numberofpoints(tio::RawTetGenIO{T}) where T= size(tio.pointlist,2)
+
+"""
+$(TYPEDSIGNATURES)
+
+Number of tetrahedra in tetrahedralization
+"""
+numberoftetrahedra(tio::RawTetGenIO{T}) where T= size(tio.tetrahedronlist,2)
+
+"""
+$(TYPEDSIGNATURES)
+
+Number of triangle faces in tetrahedralization
+"""
+numberoftrifaces(tio::RawTetGenIO{T}) where T= size(tio.trifacelist,2)
+
+"""
+$(TYPEDSIGNATURES)
+
+Number of edges in tetrahedralization
+"""
+numberofedges(tio::RawTetGenIO{T}) where T= size(tio.edgelist,2)
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Tetrahedralize input.
+
+````
+  flags: -pYrq_Aa_miO_S_T_XMwcdzfenvgkJBNEFICQVh 
+    -p  Tetrahedralizes a piecewise linear complex (PLC).
+    -Y  Preserves the input surface mesh (does not modify it).
+    -r  Reconstructs a previously generated mesh.
+    -q  Refines mesh (to improve mesh quality).
+    -R  Mesh coarsening (to reduce the mesh elements).
+    -A  Assigns attributes to tetrahedra in different regions.
+    -a  Applies a maximum tetrahedron volume constraint.
+    -m  Applies a mesh sizing function.
+    -i  Inserts a list of additional points.
+    -O  Specifies the level of mesh optimization.
+    -S  Specifies maximum number of added points.
+    -T  Sets a tolerance for coplanar test (default 1e-8).
+    -X  Suppresses use of exact arithmetic.
+    -M  No merge of coplanar facets or very close vertices.
+    -w  Generates weighted Delaunay (regular) triangulation.
+    -c  Retains the convex hull of the PLC.
+    -d  Detects self-intersections of facets of the PLC.
+    -z  Numbers all output items starting from zero.
+    -f  Outputs all faces to .face file.
+    -e  Outputs all edges to .edge file.
+    -n  Outputs tetrahedra neighbors to .neigh file.
+    -v  Outputs Voronoi diagram to files.
+    -g  Outputs mesh to .mesh file for viewing by Medit.
+    -k  Outputs mesh to .vtk file for viewing by Paraview.
+    -J  No jettison of unused vertices from output .node file.
+    -B  Suppresses output of boundary information.
+    -N  Suppresses output of .node file.
+    -E  Suppresses output of .ele file.
+    -F  Suppresses output of .face and .edge file.
+    -I  Suppresses mesh iteration numbers.
+    -C  Checks the consistency of the final mesh.
+    -Q  Quiet:  No terminal output except errors.
+    -V  Verbose:  Detailed information, more terminal output.
+    -h  Help:  A brief instruction for using TetGen.
+````
+"""
+function tetrahedralize(input::RawTetGenIO{Float64}, flags::String)
+    cinput,flist,plist=CPPTetGenIO(input)
+    coutput = ccall((:tetrahedralizef64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring), cinput, flags)
+    RawTetGenIO(coutput)
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Create GeometryBasics.Mesh from the triface list
+(for quick visualization purposes using Makie's wireframe).
+"""
+function surfacemesh(tgio::RawTetGenIO)
+    points=[ Point3f0(tgio.pointlist[:,i]...) for i=1:size(tgio.pointlist,2)]
+    faces= [TriangleFace(tgio.trifacelist[:,i]...) for i=1:size(tgio.trifacelist,2)]
+    mesh=GeometryBasics.Mesh(points,faces)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Create GeometryBasics.Mesh of all tetrahedron faces
+(for quick visualization purposes using Makie's wireframe).
+"""
+function volumemesh(tgio::RawTetGenIO)
+    points=[ Point3f0(tgio.pointlist[:,i]...) for i=1:size(tgio.pointlist,2)]
+    faces=Array{NgonFace{3,Int32},1}(undef,0)
+    tetlist=tgio.tetrahedronlist
+    for itet=1:size(tetlist,2)
+        tet=view(tetlist,:, itet)
+        push!(faces,TriangleFace(tet[1],tet[2],tet[3]))
+        push!(faces,TriangleFace(tet[1],tet[2],tet[4]))
+        push!(faces,TriangleFace(tet[2],tet[3],tet[4]))
+        push!(faces,TriangleFace(tet[3],tet[1],tet[4]))
+    end
+    mesh=GeometryBasics.Mesh(points,faces)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TetGen
-using TetGen: JLPolygon, TetgenIO, JLFacet, Point
+using TetGen: JLPolygon, JLFacet, Point
 using GeometryBasics
 using GeometryBasics: Mesh, Triangle, Tetrahedron, TriangleFace, QuadFace,
     PointMeta, NgonFaceMeta, meta, faces, metafree

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,3 +48,52 @@ result = TetGen.voronoi(points)
 # s = Sphere{Float64}(Point(0.0, 0.0, 0.0), 1.0)
 #
 # y = PlainMesh{Float64, Triangle{Cint}}(s)
+
+include("../examples/examples.jl")
+function generic_test(result::RawTetGenIO)
+    @test volumemesh(result) isa Mesh
+
+    if numberoftrifaces(result)>0
+        @test surfacemesh(result) isa Mesh
+    end
+    
+    buf=IOBuffer()
+    Base.show(buf,result)
+    @test length(buf.data)>0
+    
+    ctio,flist,plist=TetGen.CPPTetGenIO(result)
+    @test ctio.numberofpoints==numberofpoints(result)
+    @test ctio.numberoftetrahedra==numberoftetrahedra(result)
+    @test ctio.numberoftrifaces==numberoftrifaces(result)
+end
+
+result = random_delaunay(npoints=100)
+@test numberofpoints(result)==100
+generic_test(result)
+
+result = cube()
+@test numberofpoints(result)==8
+@test numberoftetrahedra(result)==6
+@test numberofedges(result)==12
+@test numberoftrifaces(result)==12
+generic_test(result)
+
+result = prism()
+@test numberofpoints(result)==8
+@test numberofedges(result)==11
+@test numberoftrifaces(result)==12
+@test numberoftetrahedra(result)==6
+generic_test(result)
+
+
+# exact numbers depend on FP aritmetic and
+# compiler optimizations
+result = material_prism()
+@test numberoftetrahedra(result)>100
+generic_test(result)
+
+result = cutprism()
+@test numberoftetrahedra(result)>100
+generic_test(result)
+
+


### PR DESCRIPTION
With this PR, two structs can be used to interface TetGen
- JLTetGenIO (formerly TetGenIO) supporting the existing, unmodified GeometryBasics.Mesh based API
- RawTetGenIO essentially passing arrays 1:1 from/to C++
