### PR TITLE
Update of upstream patch version of TetGen and API improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "1.1.0"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -16,8 +15,8 @@ TetGen_jll = "b47fdcd6-d2c1-58e9-bbba-c1cee8d8c179"
 DocStringExtensions = "^0.8"
 GeometryBasics = "0.2, 0.3"
 StaticArrays = "0.11, 0.12"
-julia = "1.3"
 TetGen_jll = "1.5.1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "TetGen"
 uuid = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 authors = ["SimonDanisch <sdanisch@gmail.com>", "Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TetGen_jll = "b47fdcd6-d2c1-58e9-bbba-c1cee8d8c179"
 
@@ -14,8 +16,8 @@ TetGen_jll = "b47fdcd6-d2c1-58e9-bbba-c1cee8d8c179"
 DocStringExtensions = "^0.8"
 GeometryBasics = "0.2, 0.3"
 StaticArrays = "0.11, 0.12"
-TetGen_jll = "^1.5.1"
 julia = "1.3"
+TetGen_jll = "1.5.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The `TetGen.jl` package is a Julia wrapper for the C++ project [TetGen](https://wias-berlin.de/software/index.jsp?id=TetGen&lang=1). This wrapper enables TetGen based tetrahedral meshing, and (constrained) 3D Delaunay and Voronoi tesselation.
 
-## Example
+## Example using GeometryBasics datatypes
 
 ```julia
 using TetGen
@@ -49,6 +49,55 @@ GLMakie.wireframe!(result)
 Plotted with Makie:
 
 ![image](https://user-images.githubusercontent.com/1010467/82307971-69252000-99c1-11ea-8b82-e3a206381bd3.png)
+
+
+## Example using plain Julia arrays
+
+```julia
+using TetGen
+let
+    tetunsuitable() do pa,pb,pc,pd
+        vol=det(hcat(pb-pa,pc-pa,pd-pa))/6
+        center=0.25*(pa+pb+pc+pd)-[0.5,0.5,0.5]
+        vol> 0.05*norm(center)^2.5
+    end
+
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     1 1 1;
+                     0 1 1]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8]')
+    tetrahedralize(input, "pQa")
+end
+```
+
+Output:
+
+```julia
+RawTetGenIO(
+numberofpoints=169,
+numberofedges=27,
+numberoftrifaces=112,
+numberoftetrahedra=809,
+pointlist'=[0.0 1.0 … 0.500059730245037 0.4996534431688176; 0.0 0.0 … 0.5074057466787957 0.49707528530503103; 0.0 0.0 … 0.5033015055704277 0.4953177845338027],
+tetrahedronlist'=Int32[34 47 … 15 143; 6 24 … 143 15; 58 52 … 154 150; 70 73 … 168 168],
+trifacelist'=Int32[3 58 … 99 22; 19 6 … 22 8; 78 70 … 158 158],
+trifacemarkerlist'=Int32[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1  …  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
+edgelist'=Int32[3 5 … 70 157; 18 24 … 6 32],
+edgemarkerlist'=Int32[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1  …  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
+)
+```
 
 
 ## [Contributing](https://github.com/JuliaGeometry/TetGen.jl/blob/master/CONTRIBUTING.md)   

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  # Define coverage range and precision
+  precision: 2
+  range: "70..100"
+
+# ignore:
+  # - "path/to/folder"  # ignore folders and all its contents
+  # - "test_*.rb"       # wildcards accepted
+  # - "**/*.py"   

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  # Define coverage range and precision
-  precision: 2
-  range: "70..100"
-
-# ignore:
-  # - "path/to/folder"  # ignore folders and all its contents
-  # - "test_*.rb"       # wildcards accepted
-  # - "**/*.py"   

--- a/examples/examples.jl
+++ b/examples/examples.jl
@@ -1,4 +1,5 @@
 using TetGen
+using LinearAlgebra
 
 """
      random_delaunay(;npoints=20)
@@ -37,6 +38,44 @@ function cube(;vol=1)
                              4 1 5 8]')
     tetrahedralize(input, "pQa$(vol)")
 end
+
+
+
+"""
+   cube_localref()
+
+   Tetrahedralization of cube with local refinement callback
+"""
+
+function cube_localref()
+
+    tetunsuitable() do pa,pb,pc,pd
+        vol=det(hcat(pb-pa,pc-pa,pd-pa))/6
+        center=0.25*(pa+pb+pc+pd)-[0.5,0.5,0.5]
+        vol> 0.05*norm(center)^2.5
+    end
+
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     1 1 1;
+                     0 1 1]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8]')
+    tetrahedralize(input, "pQa")
+end
+
+
+
 
 """
    prism(;vol=1)

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -1,21 +1,6 @@
 module TetGen
 using DocStringExtensions
 using TetGen_jll
-using Libdl
-
-
-# Do this here as we appearantly cannot pin build numbers in [compat}
-# At least we provide an error message here if this fails.
-function __init__()
-    lib=something(Libdl.dlopen_e(libtet,Libdl.RTLD_NOW),C_NULL)
-    try
-        sym = Libdl.dlsym(lib, :tetrahedralize2_f64)  
-    catch err
-        println(err)
-        println("Ensure updating TetGen_jll to version 1.5.1+1")
-        rethrow(err)
-    end
-end
 
 using GeometryBasics
 using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line,

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -1,11 +1,30 @@
 module TetGen
 using DocStringExtensions
 using TetGen_jll
+using Libdl
+
+
+# Do this here as we appearantly cannot pin build numbers in [compat}
+# At least we provide an error message here if this fails.
+function __init__()
+    lib=something(Libdl.dlopen_e(libtet,Libdl.RTLD_NOW),C_NULL)
+    try
+        sym = Libdl.dlsym(lib, :tetrahedralize2_f64)  
+    catch err
+        println(err)
+        println("Ensure updating TetGen_jll to version 1.5.1+1")
+        rethrow(err)
+    end
+end
+
 using GeometryBasics
 using GeometryBasics: Polygon, MultiPolygon, Point, LineFace, Polytope, Line,
     Simplex, connect, Triangle, NSimplex, Tetrahedron,
     TupleView, TriangleFace, SimplexFace, LineString, Mesh, TetrahedronP, TriangleP,
     NgonFace, Ngon, faces, coordinates, metafree, meta, faces
+
+
+using Printf
 
 using StaticArrays
 
@@ -18,6 +37,8 @@ include("api.jl")
 
 
 export tetrahedralize
+export tetunsuitable
+export TetGenError
 export RawTetGenIO, facetlist!, RawFacet
 export numberofpoints,numberoftetrahedra,numberoftrifaces,numberofedges
 export volumemesh,surfacemesh

--- a/src/cpptetgenio.jl
+++ b/src/cpptetgenio.jl
@@ -57,5 +57,80 @@ struct CPPTetGenIO{T}
     numberofedges::Cint
 end
 
-tetrahedralize(input::CPPTetGenIO{Float64}, command::String)=ccall((:tetrahedralizef64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring), input, command)
+"""
+   Error struct for TetGen
+"""
+struct TetGenError <: Exception
+    rc::Cint
+end
 
+"""
+   Show TetGen error, messages have been lifted
+   from TetGen 
+"""
+function Base.show(io::IO, e::TetGenError)
+    if e.rc==1
+        println(io,"TetGen error $(e.rc): out of memory."); 
+    elseif e.rc==2
+        println(io,"TetGen error $(e.rc): internal error.")
+    elseif e.rc==3
+        println(io,"TetGen error $(e.rc): a self-intersection was detected. Hint: use -d option to detect all self-intersections."); 
+    elseif e.rc==4
+        println(io,"TetGen error $(e.rc): a very small input feature size was detected. Hint: use -T option to set a smaller tolerance.")
+    elseif e.rc==5
+        println(io,"TetGen error $(e.rc): two very close input facets were detected. Hint: use -Y option to avoid adding Steiner points in boundary.\n");
+    elseif e.rc==10
+        println(io,"TetGen error $(e.rc): an input error was detected.\n"); 
+    else
+        println(io,"TetGen error $(e.rc): unknown error.\n"); 
+    end    
+end
+
+
+"""
+$(SIGNATURES)
+
+Tetrahedralization with error handling
+"""
+function tetrahedralize(input::CPPTetGenIO{Float64}, command::String)
+    rc=Cint[0]
+    output = ccall((:tetrahedralize2_f64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring,  Ptr{Cint}), input, command, rc)
+    if rc[1]!=0
+        throw(TetGenError(rc[1]))
+    end
+    output
+end
+
+
+"""
+   Trivial Julia tetunsuitable function
+"""
+my_jl_tetunsuitable=(pa,pb,pc,pd)->0
+
+
+"""
+   Tetunsuitable function called from C wrapper
+"""
+function jl_wrap_tetunsuitable(pa::Ptr{Float64}, pb::Ptr{Float64}, pc::Ptr{Float64}, pd::Ptr{Float64})
+    pax=Base.unsafe_wrap(Array,pa,(3,),own=false)
+    pbx=Base.unsafe_wrap(Array,pb,(3,),own=false)
+    pcx=Base.unsafe_wrap(Array,pc,(3,),own=false)
+    pdx=Base.unsafe_wrap(Array,pd,(3,),own=false)
+    Cint(my_jl_tetunsuitable(pax,pbx,pcx,pdx))
+end
+
+
+"""
+   Set tetunsuitable function called from C wrapper.
+   Setting this function is valid only for one subsequent
+   call to tetrahedralize     
+"""
+function tetunsuitable(unsuitable::Function;check_signature=true)
+    if check_signature
+        unsuitable(rand(3),rand(3),rand(3),rand(3))
+    end
+    global my_jl_tetunsuitable
+    my_jl_tetunsuitable=unsuitable
+    c_wrap_tetunsuitable=@cfunction(jl_wrap_tetunsuitable, Cint, (Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}))
+    ccall((:tetunsuitable_callback,libtet),Cvoid,(Ptr{Cvoid},),c_wrap_tetunsuitable)
+end

--- a/src/jltetgenio.jl
+++ b/src/jltetgenio.jl
@@ -329,8 +329,11 @@ function Base.unsafe_convert(::Type{CPPTetGenIO{T}}, x::Tuple{CPPTetGenIO{T}, Ve
 end
 
 
-
 function tetrahedralize(input::JLTetGenIO{Float64}, command::String)
-    cres = ccall((:tetrahedralizef64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring), input, command)
+    rc=Cint[0]
+    cres = ccall((:tetrahedralize2_f64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring, Ptr{Cint}), input, command,rc)
+    if rc[1]!=0
+        throw(TetGenError(rc[1]))
+    end
     return convert(JLTetGenIO, cres)
 end

--- a/src/rawtetgenio.jl
+++ b/src/rawtetgenio.jl
@@ -419,8 +419,7 @@ function CPPTetGenIO(tio::RawTetGenIO{T}) where T
             edgemarkerlist=pointer(tio.edgemarkerlist)
         end            
     end
-    
-    
+
     # Create struct
     CPPTetGenIO{T}(firstnumber,
                    mesh_dim,
@@ -469,10 +468,10 @@ function RawTetGenIO(ctio::CPPTetGenIO{T}) where T
         tio.pointlist = convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointlist, (3,Int(ctio.numberofpoints)), own=true))
     end
     if ctio.numberofpointattributes>0  && ctio.pointattributelist!=C_NULL
-        tio.pointattributelist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointattributelistlist, (Int(ctio.numberofpointattributes),Int(ctio.numberofpoints)), own=true))
+        tio.pointattributelist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointattributelist, (Int(ctio.numberofpointattributes),Int(ctio.numberofpoints)), own=true))
     end
     if ctio.numberofpointmtrs>0  && ctio.pointmtrlist!=C_NULL
-        tio.pointmtrlist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointmtrlistlist, (Int(ctio.numberofpointmtrs),Int(ctio.numberofpoints)), own=true))
+        tio.pointmtrlist=convert(Array{T,2}, Base.unsafe_wrap(Array, ctio.pointmtrlist, (Int(ctio.numberofpointmtrs),Int(ctio.numberofpoints)), own=true))
     end
     if ctio.pointmarkerlist!=C_NULL
         tio.pointmarkerlist=convert(Array{Cint,1}, Base.unsafe_wrap(Array, ctio.pointmarkerlist, (Int(ctio.numberofpoints)), own=true))
@@ -626,7 +625,12 @@ Tetrahedralize input.
 """
 function tetrahedralize(input::RawTetGenIO{Float64}, flags::String)
     cinput,flist,plist=CPPTetGenIO(input)
-    coutput = ccall((:tetrahedralizef64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring), cinput, flags)
+    rc=Cint[0]
+    coutput = ccall((:tetrahedralize2_f64, libtet), CPPTetGenIO{Float64}, (CPPTetGenIO{Float64}, Cstring, Ptr{Cint}),
+                    cinput, flags, rc)
+    if rc[1]!=0
+        throw(TetGenError(rc[1]))
+    end
     RawTetGenIO(coutput)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,35 @@ result = tetrahedralize(tetmesh,"pQqAa0.01")
 #
 # y = PlainMesh{Float64, Triangle{Cint}}(s)
 
+
+
+
+
+input=TetGen.RawTetGenIO{Cdouble}()
+input.pointlist=[0 0 0;  
+                 1 0 0;
+                 1 1 0;
+                 0 1 0;
+                 0 0 1;  
+                 1 0 1;
+                 1 1 1;
+                 0 1 1]'
+
+TetGen.facetlist!(input,[1 2 3 4;
+                         5 6 7 8;
+                         1 2 6 5;
+                         2 3 7 6;
+                         3 4 8 7;
+                         4 1 5 8]')
+
+cinput,x1,x2=TetGen.CPPTetGenIO(input)
+coutput=tetrahedralize(cinput, "pQa")
+
+@test coutput.numberofpoints==8
+
+
+
+
 include("../examples/examples.jl")
 function generic_test(result::RawTetGenIO)
     @test volumemesh(result) isa Mesh

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,7 @@ result = cube()
 @test numberoftrifaces(result)==12
 generic_test(result)
 
+
 result = prism()
 @test numberofpoints(result)==8
 @test numberofedges(result)==11
@@ -114,6 +115,11 @@ generic_test(result)
 
 # exact numbers depend on FP aritmetic and
 # compiler optimizations
+
+result = cube_localref()
+generic_test(result)
+
+
 result = material_prism()
 @test numberoftetrahedra(result)>100
 generic_test(result)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,12 @@ result = prism()
 generic_test(result)
 
 
+
+
+
+
+
+
 # exact numbers depend on FP aritmetic and
 # compiler optimizations
 result = material_prism()
@@ -116,4 +122,93 @@ result = cutprism()
 @test numberoftetrahedra(result)>100
 generic_test(result)
 
+
+
+
+
+
+
+
+function badcube1(;vol=1)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 2;
+                     1 1 1;
+                     0 1 2]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8]')
+    tetrahedralize(input, "pQa$(vol)")
+end
+
+function badcube2(;vol=1)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     1 1 1;
+                     0 1 1;
+                     0 1 1-1.0e-5;
+                     ]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8]')
+    tetrahedralize(input, "pQa$(vol)")
+end
+
+
+function badcube3(;vol=1)
+    input=TetGen.RawTetGenIO{Cdouble}()
+    input.pointlist=[0 0 0;  
+                     1 0 0;
+                     1 1 0;
+                     0 1 0;
+                     0 0 1;  
+                     1 0 1;
+                     1 1 1;
+                     0 1 1;
+                     ]'
+
+    TetGen.facetlist!(input,[1 2 3 4;
+                             5 6 7 8;
+                             1 2 6 5;
+                             2 3 7 6;
+                             3 4 8 7;
+                             4 1 5 8;
+                             1 2 8 7;
+                             3 4 6 5;
+                             ]')
+    tetrahedralize(input, "pQa$(vol)q")
+end
+
+function test_catch_error(geom)
+    try
+        result=geom()
+    catch err
+        if typeof(err)==TetGenError
+            println("Catched TetGenError")
+            println(err)
+            return true
+        end
+    end
+    false
+end
+
+@test test_catch_error(badcube2)
+#@test test_catch_error(badcube3)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,30 +73,6 @@ result = tetrahedralize(tetmesh,"pQqAa0.01")
 
 
 
-input=TetGen.RawTetGenIO{Cdouble}()
-input.pointlist=[0 0 0;  
-                 1 0 0;
-                 1 1 0;
-                 0 1 0;
-                 0 0 1;  
-                 1 0 1;
-                 1 1 1;
-                 0 1 1]'
-
-TetGen.facetlist!(input,[1 2 3 4;
-                         5 6 7 8;
-                         1 2 6 5;
-                         2 3 7 6;
-                         3 4 8 7;
-                         4 1 5 8]')
-
-cinput,x1,x2=TetGen.CPPTetGenIO(input)
-coutput=tetrahedralize(cinput, "pQa")
-
-@test coutput.numberofpoints==8
-
-
-
 
 include("../examples/examples.jl")
 function generic_test(result::RawTetGenIO)
@@ -207,29 +183,6 @@ function badcube2(;vol=1)
 end
 
 
-function badcube3(;vol=1)
-    input=TetGen.RawTetGenIO{Cdouble}()
-    input.pointlist=[0 0 0;  
-                     1 0 0;
-                     1 1 0;
-                     0 1 0;
-                     0 0 1;  
-                     1 0 1;
-                     1 1 1;
-                     0 1 1;
-                     ]'
-
-    TetGen.facetlist!(input,[1 2 3 4;
-                             5 6 7 8;
-                             1 2 6 5;
-                             2 3 7 6;
-                             3 4 8 7;
-                             4 1 5 8;
-                             1 2 8 7;
-                             3 4 6 5;
-                             ]')
-    tetrahedralize(input, "pQa$(vol)q")
-end
 
 function test_catch_error(geom)
     try
@@ -246,4 +199,39 @@ end
 
 @test test_catch_error(badcube2)
 #@test test_catch_error(badcube3)
+
+##############################################
+# Solely for increasing codecov
+
+
+
+input=TetGen.RawTetGenIO{Cdouble}()
+input.pointlist=[0 0 0;  
+                 1 0 0;
+                 1 1 0;
+                 0 1 0;
+                 0 0 1;  
+                 1 0 1;
+                 1 1 1;
+                 0 1 1]'
+
+TetGen.facetlist!(input,[1 2 3 4;
+                         5 6 7 8;
+                         1 2 6 5;
+                         2 3 7 6;
+                         3 4 8 7;
+                         4 1 5 8]')
+
+cinput,x1,x2=TetGen.CPPTetGenIO(input)
+coutput=tetrahedralize(cinput, "pQa")
+
+@test coutput.numberofpoints==8
+
+function test_error_output()
+    for i=1:10 
+        println( TetGenError(i))
+    end
+    true
+end
+@test test_error_output()
 


### PR DESCRIPTION
* Update of upstream patch version of TetGen to "August 18, 2018". Formally this still appears to be 1.5.1 , and it is manifest in TetGen_jll 1.5.1+1
* Catch errors thrown by TetGen in a rc variable, throw julia error if rc!=0
* Handle unsuitable callback to allow local refinement.