### PR TITLE
fix version check for `MemoryRef`

### DIFF
--- a/src/jltetgenio.jl
+++ b/src/jltetgenio.jl
@@ -256,7 +256,7 @@ function unsafe_array_convert(P::Type{Ptr{T1}}, x::Vector{T2}) where {T1, T2}
     Ptr{T1}(Base.unsafe_convert(Ptr{T2}, x))
 end
 
-@static if VERSION > v"1.10"
+if isdefined(Base, :MemoryRef)
     function unsafe_array_convert(P::Type{Ptr{T1}}, x::MemoryRef{T2}) where {T1, T2}
         Ptr{T1}(Base.unsafe_convert(Ptr{T2}, x))
     end


### PR DESCRIPTION
The previous one didn't really do what was intended considering ` v"1.10.1" > v"1.10" == true`. Also, the `@static` is pointless when executed at toplevel scope.