### PR TITLE
Read/write tetgen files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "TetGen"
 uuid = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 authors = ["SimonDanisch <sdanisch@gmail.com>", "Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -12,6 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TetGen_jll = "b47fdcd6-d2c1-58e9-bbba-c1cee8d8c179"
 
 [compat]
+Dates = "1.9"
 DocStringExtensions = "0.8,0.9"
 GeometryBasics = "0.4, 0.5"
 LinearAlgebra = "1"

--- a/src/TetGen.jl
+++ b/src/TetGen.jl
@@ -4,6 +4,7 @@
 $(read(joinpath(@__DIR__, "..", "README.md"), String))
 """
 module TetGen
+using Dates: now
 using DocStringExtensions: DocStringExtensions, SIGNATURES, TYPEDEF,
     TYPEDFIELDS, TYPEDSIGNATURES
 import GeometryBasics
@@ -11,7 +12,7 @@ using GeometryBasics: Point, Point3f, LineFace, Polytope, Triangle,
     TriangleFace, SimplexFace, Mesh, Tetrahedron, Triangle,
     NgonFace, faces, coordinates
 
-using Printf: Printf
+using Printf: Printf, @sprintf
 using StaticArrays: StaticArrays, SVector
 using TetGen_jll: TetGen_jll, libtet
 

--- a/src/rawtetgenio.jl
+++ b/src/rawtetgenio.jl
@@ -731,3 +731,83 @@ function volumemesh(tgio::RawTetGenIO)
     end
     return mesh = GeometryBasics.Mesh(points, faces)
 end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Write TetGenIO input data to output stream.
+"""
+function writesmesh(io::IO, tio::RawTetGenIO)
+    shift = 1
+    npoints = size(tio.pointlist, 2)
+    dimension = 3
+    npointboundarymarkers = 0
+    npointattributes = 0
+    nfacets = length(tio.facetlist)
+    nfacetboundarymarkers = length(tio.facetmarkerlist) > 0 ? 1 : 0
+    nholes = size(tio.holelist, 2)
+    nregions = size(tio.regionlist, 2)
+
+    write(io, @sprintf("# TetGen input file\n"))
+    write(io, @sprintf("# Creator: TetGen.jl\n"))
+    write(io, @sprintf("# Creation date: %s\n", string(now())))
+    write(io, @sprintf("\n# part 1: node list."))
+    write(io, @sprintf("\n%ld %d %d %d", npoints, dimension, npointboundarymarkers, npointattributes))
+    for ipoint in 1:npoints
+        write(
+            io, @sprintf(
+                "\n%ld %.17g %.17g %.17g", ipoint - 1,
+                tio.pointlist[1, ipoint], tio.pointlist[2, ipoint], tio.pointlist[3, ipoint]
+            )
+        )
+    end
+    write(io, @sprintf("\n\n# part 2: facet list."))
+    write(io, @sprintf("\n%ld %d", nfacets, nfacetboundarymarkers))
+    for ifacet in 1:nfacets
+        facet = tio.facetlist[ifacet].polygonlist[1]
+        ncorners = length(facet)
+        write(io, @sprintf("\n%ld ", ncorners))
+        for icorner in 1:ncorners
+            write(io, @sprintf("%ld ", facet[icorner] - 1))
+        end
+        if nfacetboundarymarkers > 0
+            write(io, @sprintf("%ld ", tio.facetmarkerlist[ifacet]))
+        end
+    end
+    write(io, @sprintf("\n\n# part 3: hole list."))
+    write(io, @sprintf("\n%ld", nholes))
+    for ihole in 1:nholes
+        write(
+            io, @sprintf(
+                "\n%ld %.17g %.17g %.17g", ihole - 1,
+                tio.holelist[1, ihole], tio.holelist[2, ihole], tio.holelist[3, ihole]
+            )
+        )
+    end
+    write(io, @sprintf("\n\n# part 4: region list."))
+    write(io, @sprintf("\n%ld", nregions))
+    for iregion in 1:nregions
+        write(
+            io, @sprintf(
+                "\n%ld %.17g %.17g %.17g %f %.17g", iregion - 1,
+                tio.regionlist[1, iregion], tio.regionlist[2, iregion], tio.regionlist[3, iregion],
+                tio.regionlist[4, iregion], tio.regionlist[5, iregion]
+            )
+        )
+    end
+    write(io, "\n")
+    return
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Write TetGenIO input data to TetGen .smesh file.
+"""
+function writesmesh(fname::String, tio::RawTetGenIO)
+    open(fname, "w") do io
+        writesmesh(io, tio)
+    end
+    return
+end


### PR DESCRIPTION
Allow to read/write tetgen .smesh and tetgen .ele files.
This would allow to communicate with TetGen executables from different versions, in oder to support the newly restarted development process on https://codeberg.org/TetGen/TetGen.

The general plan would be the following

- [x] Create a method to write out .smesh files
- [ ] Make a TokenStreams.jl package based on https://github.com/WIAS-PDELib/ExtendableGrids.jl/blob/master/src/tokenstream.jl
- [ ] Add a method read in .ele files in the spirit of https://github.com/WIAS-PDELib/ExtendableGrids.jl/blob/042df1d4e2b13ddc98eb299c2a763bfd3a1b8f11/src/io.jl#L269

An alternative would be to update the c++ wrapper like in https://github.com/JuliaPackaging/Yggdrasil/blob/6e57006af5be3cb2f6c24979ab934cbd5f8d61cd/T/TetGen/cwrapper/cwrapper.cxx#L268  , however it is not clear how stable the library interface would be (but in fact is is more fun to code in Julia... )

@pjaap, @sihang0592

